### PR TITLE
Fix bug in post urls from categories

### DIFF
--- a/categories.html
+++ b/categories.html
@@ -16,7 +16,7 @@ title: Categories
     <a name="{{ category_name | slugize }}"></a>
     {% for post in site.categories[category_name] %}
     <article class="archive-item">
-      <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+      <h4><a href="{{ post.url }}">{{post.title}}</a></h4>
     </article>
     {% endfor %}
   </div>


### PR DESCRIPTION
Urls were failing in categories.html.
This commit creates the urls the same way as in the other (working) places, but as @mcebey points out this is not a definitive solution because this way supposes urls are always based on the root of a domain.