### PR TITLE
Fix relative urls

### DIFF
--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,3 +1,4 @@
 # _config.yml - Base config used in production
+url:              /
 baseurl:          /
 google_analytics: UA-XXXXXXX-X

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -27,7 +27,7 @@
       {% for node in pages_list %}
         {% if node.title != null %}
           {% if node.layout == "page" %}
-            <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
+            <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ site.url }}{{ node.url }}">{{ node.title }}</a>
           {% endif %}
         {% endif %}
       {% endfor %}

--- a/archive.md
+++ b/archive.md
@@ -15,7 +15,7 @@ Aquí podrás encontrar todas las publicaciones en orden cronológico
     <ul>
     {% assign date = currentdate %}
   {% endif %}
-    <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+    <li><a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></li>
   {% if forloop.last %}</ul>{% endif %}
 {% endfor %}
 </div>

--- a/categories.html
+++ b/categories.html
@@ -16,7 +16,7 @@ title: Categories
     <a name="{{ category_name | slugize }}"></a>
     {% for post in site.categories[category_name] %}
     <article class="archive-item">
-      <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+      <h4><a href="{{ post.url }}">{{post.title}}</a></h4>
     </article>
     {% endfor %}
   </div>

--- a/categories.html
+++ b/categories.html
@@ -16,7 +16,7 @@ title: Categories
     <a name="{{ category_name | slugize }}"></a>
     {% for post in site.categories[category_name] %}
     <article class="archive-item">
-      <h4><a href="{{ post.url }}">{{post.title}}</a></h4>
+      <h4><a href="{{ site.url }}{{ post.url }}">{{post.title}}</a></h4>
     </article>
     {% endfor %}
   </div>

--- a/index.html
+++ b/index.html
@@ -6,15 +6,15 @@ title: Home
   {% for post in paginator.posts %}
   <div class="post">
     <h1 class="post-title">
-      <a href="{{ post.url }}">
+      <a href="{{ site.url }}{{ post.url }}">
         {{ post.title }}
       </a>
     </h1>
-    <span class="post-date">{{ post.date | date_to_string }} | <a href="{{ post.url }}#disqus_thread">Comentarios</a></span>
+    <span class="post-date">{{ post.date | date_to_string }} | <a href="{{ site.url }}{{ post.url }}#disqus_thread">Comentarios</a></span>
 
     {{ post.content | split:'<!--break-->' | first }}
     {% if post.content contains '<!--break-->' %}
-        <a href="{{ post.url }}">...</a>
+    <a href="{{ site.url }}{{ post.url }}">...</a>
      {% endif %}
 
   </div>


### PR DESCRIPTION
This way all links to posts from categories, archive, etc., as well as links to pages from the index can work even when the blog is not deployed into a root domain.

Working sample: https://pepellou.github.io/chess-is-hard/ 😬